### PR TITLE
Chore(deps): downgrade conventional-changelog-conventionalcommits from v7 to v6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
         patterns:
           - "@typescript-eslint/*"
           - "eslint-plugin-unused-imports"
+    ignore:
+      - dependency-name: "conventional-changelog-conventionalcommits"
+        update-types: ["version-update:semver-major"]
   
   - package-ecosystem: github-actions
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-unused-imports": "^3.0.0"
       },
       "devDependencies": {
-        "conventional-changelog-conventionalcommits": "^7.0.2",
+        "conventional-changelog-conventionalcommits": "^6.1.0",
         "eslint": "^8.49.0",
         "eslint-define-config": "^1.23.0",
         "semantic-release": "^21.1.1"
@@ -1602,15 +1602,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
+      "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-unused-imports": "^3.0.0"
   },
   "devDependencies": {
-    "conventional-changelog-conventionalcommits": "^7.0.2",
+    "conventional-changelog-conventionalcommits": "^6.1.0",
     "eslint": "^8.49.0",
     "eslint-define-config": "^1.23.0",
     "semantic-release": "^21.1.1"


### PR DESCRIPTION
breaking changes of conventional-changelog-conventionalcommits have been released as a major update, but the current version of semantic-release has no compatibility and that causes some issues.
This PR will revert the major update of conventional-changelog-conventionalcommits temporary and make this repo's workflow work fine.
In future, when semantic-release become compatible with the latest version of it, it should be addressed manually.

Also currently updating it by dependabot should be stopped.

Actually I'm not sure this changes make the workflows work fine, but at least applying this change is better at the current time as far as I saw some issues on the semantic-release's repo.